### PR TITLE
Correct script attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ==========
 
+### 3.0.6 - May 6, 2023
+
+Updating Fathom script to use `data-site` instead of `site`
+
 ### 3.0.5 - Dec 7, 2021
 
 Fixed security issue where an administrator could inject XSS code into the Analytics tab and gain access to super administrator accounts on a multi-site installation.

--- a/fathom-analytics.php
+++ b/fathom-analytics.php
@@ -3,7 +3,7 @@
 Plugin Name: Fathom Analytics
 Description: A simple plugin to add the Fathom tracking snippet to your WordPress site.
 Author: Conva Ventures Inc
-Version: 3.0.5
+Version: 3.0.6
 
 Fathom Analytics for WordPress
 Copyright (C) 2020 Conva Ventures Inc

--- a/fathom-analytics.php
+++ b/fathom-analytics.php
@@ -107,9 +107,9 @@ function fathom_print_js_snippet()
     } ?>
    <!-- Fathom - beautiful, simple website analytics -->
   <?php if (empty(fathom_get_custom_domain())): ?>
-    <script src="https://cdn.usefathom.com/script.js" site="<?php echo esc_attr($site_id); ?>" data-no-minify=""></script>
+    <script src="https://cdn.usefathom.com/script.js" data-site="<?php echo esc_attr($site_id); ?>" data-no-minify=""></script>
    <?php else: ?>
-    <script src="https://<?php echo str_replace(['http://', 'https://', '/'], '', esc_attr(fathom_get_custom_domain())); ?>/script.js" site="<?php echo esc_attr($site_id); ?>" data-no-minify=""></script>
+    <script src="https://<?php echo str_replace(['http://', 'https://', '/'], '', esc_attr(fathom_get_custom_domain())); ?>/script.js" data-site="<?php echo esc_attr($site_id); ?>" data-no-minify=""></script>
    <?php endif; ?>
    <!-- / Fathom -->
    <?php

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,10 @@ You may think that digital privacy doesn’t matter because you have nothing to 
 
 == Changelog ==
 
+### 3.0.6 - May 6, 2023
+
+Updating Fathom script to use data-site instead of site
+
 ### 3.0.5 - Dec 7, 2021
 
 Fixed security issue where an administrator could inject XSS code into the Analytics tab and gain access to super administrator accounts on a multi-site installation.


### PR DESCRIPTION
The script example in documentation uses a `data-site` attribute for embedding the Fathom script.

This PR brings the WP plugin inline with documentation and also satisfies W3 validation where `site` is not a valid attribute of a `script`.

Thanks!