### PR TITLE
Add filter to stats page in admin

### DIFF
--- a/trunk/fathom-analytics.php
+++ b/trunk/fathom-analytics.php
@@ -140,7 +140,7 @@ function fathom_stats_page() {
     add_menu_page(
         __( 'Fathom Analytics', 'fathom-analytics' ),
         'Fathom Analytics',
-        'edit_pages',
+        apply_filters( 'fathom_stats_required_capability', 'edit_pages' ),
         'analytics',
         'fathom_print_stats_page',
         fathom_get_menu_icon(),


### PR DESCRIPTION
The current `edit_pages` capability of the plugin for seeing analytics requires a user to be at least an `editor`, which by default is probably the correct capability. In some cases, sites may wish to allow users of the `author` or even `contributor` roles access to see stats as well. Since this is just seeing analytics, seems low risk. This filter would allow a developer to change the capability required with minimal effort, without having to add a whole UI to the settings screen.

https://wordpress.org/documentation/article/roles-and-capabilities/#edit_pages